### PR TITLE
Fixes INADDR_NONE  (#6659)

### DIFF
--- a/cores/esp32/IPAddress.cpp
+++ b/cores/esp32/IPAddress.cpp
@@ -120,3 +120,6 @@ bool IPAddress::fromString(const char *address)
     _address.bytes[3] = acc;
     return true;
 }
+
+// declared one time - as external in IPAddress.h
+IPAddress INADDR_NONE(0, 0, 0, 0);

--- a/cores/esp32/IPAddress.h
+++ b/cores/esp32/IPAddress.h
@@ -91,6 +91,6 @@ public:
     friend class DNSClient;
 };
 
-const IPAddress INADDR_NONE(0, 0, 0, 0);
-
+// changed to extern because const declaration creates copies in BSS of INADDR_NONE for each CPP unit that includes it
+extern IPAddress INADDR_NONE;
 #endif

--- a/libraries/AsyncUDP/src/AsyncUDP.h
+++ b/libraries/AsyncUDP/src/AsyncUDP.h
@@ -7,7 +7,6 @@
 #include "Stream.h"
 #include <functional>
 extern "C" {
-#include "lwip/ip_addr.h"
 #include "esp_netif.h"
 #include "freertos/queue.h"
 #include "freertos/semphr.h"

--- a/libraries/WiFi/src/WiFiServer.h
+++ b/libraries/WiFi/src/WiFiServer.h
@@ -22,7 +22,6 @@
 #include "Arduino.h"
 #include "Server.h"
 #include "WiFiClient.h"
-#include "arpa/inet.h"
 #include "IPAddress.h"
 
 class WiFiServer : public Server {
@@ -38,7 +37,8 @@ class WiFiServer : public Server {
   public:
     void listenOnLocalhost(){}
 
-    WiFiServer(uint16_t port=80, uint8_t max_clients=4):sockfd(-1),_accepted_sockfd(-1),_addr(INADDR_ANY),_port(port),_max_clients(max_clients),_listening(false),_noDelay(false) {
+    // _addr(INADDR_ANY) is the same as _addr() ==> 0.0.0.0
+    WiFiServer(uint16_t port=80, uint8_t max_clients=4):sockfd(-1),_accepted_sockfd(-1),_addr(),_port(port),_max_clients(max_clients),_listening(false),_noDelay(false) {
       log_v("WiFiServer::WiFiServer(port=%d, ...)", port);
     }
     WiFiServer(const IPAddress& addr, uint16_t port=80, uint8_t max_clients=4):sockfd(-1),_accepted_sockfd(-1),_addr(addr),_port(port),_max_clients(max_clients),_listening(false),_noDelay(false) {

--- a/tools/sdk/esp32/include/wifi_provisioning/include/wifi_provisioning/wifi_config.h
+++ b/tools/sdk/esp32/include/wifi_provisioning/include/wifi_provisioning/wifi_config.h
@@ -15,7 +15,7 @@
 #ifndef _WIFI_PROV_CONFIG_H_
 #define _WIFI_PROV_CONFIG_H_
 
-#include <lwip/inet.h>
+#include <lwip/ip4_addr.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tools/sdk/esp32c3/include/wifi_provisioning/include/wifi_provisioning/wifi_config.h
+++ b/tools/sdk/esp32c3/include/wifi_provisioning/include/wifi_provisioning/wifi_config.h
@@ -15,7 +15,7 @@
 #ifndef _WIFI_PROV_CONFIG_H_
 #define _WIFI_PROV_CONFIG_H_
 
-#include <lwip/inet.h>
+#include <lwip/ip4_addr.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tools/sdk/esp32s2/include/wifi_provisioning/include/wifi_provisioning/wifi_config.h
+++ b/tools/sdk/esp32s2/include/wifi_provisioning/include/wifi_provisioning/wifi_config.h
@@ -15,7 +15,7 @@
 #ifndef _WIFI_PROV_CONFIG_H_
 #define _WIFI_PROV_CONFIG_H_
 
-#include <lwip/inet.h>
+#include <lwip/ip4_addr.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tools/sdk/esp32s3/include/wifi_provisioning/include/wifi_provisioning/wifi_config.h
+++ b/tools/sdk/esp32s3/include/wifi_provisioning/include/wifi_provisioning/wifi_config.h
@@ -15,7 +15,7 @@
 #ifndef _WIFI_PROV_CONFIG_H_
 #define _WIFI_PROV_CONFIG_H_
 
-#include <lwip/inet.h>
+#include <lwip/ip4_addr.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Description of Change

Fixes IPAddress INADDR_NONE declaration when using Arduino WiFi or ETH.
This symbol was defined as 0xffffffff by lwip /inet.h, making it impossible to use INADDR_NONE correctly.

This PR only works when <wifi-provisioning/wifi_config.h> has a modification to include <lwip/ip4_addr.h> instead of <lwip/inet.h>. This will be done directly to the sdk folder in the github structure and it has been fixed in IDF by a separated Merge Request. This will be reflected in the future, for good.

Tests scenarios

This PR was tested with all Arduino WiFi examples, including AsyncUDP. Also with ETH examples.
It was also tested for #6610 test cases.
Testing done for ESP32, ESP32-S2, ESP32-C3 and ESP32-S3.

Related links

fixes #6610
fixes #6247
fixes #4732

*By completing this PR sufficiently, you help us to improve the quality of Release Notes*

### Checklist
1. [ ] Please provide specific title of the PR describing the change, including the component name (eg. *„Update of Documentation link on Readme.md“*)
2. [ ] Please provide related links (eg. Issue, other Project, submodule PR..)
3. [ ] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

*This entire section above can be deleted if all items are checked.*

-----------
## Summary
Please describe your proposed PR and what it contains.

## Impact
Please describe impact of your PR and it's function.

## Related links
Please provide links to related issue, PRs etc.
