### PR TITLE
Update PlatformIO scripts for the upcoming 3.0 core (#8183)

### DIFF
--- a/.github/scripts/install-platformio-esp32.sh
+++ b/.github/scripts/install-platformio-esp32.sh
@@ -3,8 +3,8 @@
 export PLATFORMIO_ESP32_PATH="$HOME/.platformio/packages/framework-arduinoespressif32"
 PLATFORMIO_ESP32_URL="https://github.com/platformio/platform-espressif32.git"
 
-TOOLCHAIN_VERSION="8.4.0+2021r2-patch5"
-ESPTOOLPY_VERSION="~1.40400.0"
+TOOLCHAIN_VERSION="12.2.0+20230208"
+ESPTOOLPY_VERSION="~1.40501.0"
 ESPRESSIF_ORGANIZATION_NAME="espressif"
 
 echo "Installing Python Wheel ..."
@@ -30,9 +30,15 @@ replace_script+="data['packages']['toolchain-riscv32-esp']['owner']='$ESPRESSIF_
 # Update versions to use the upstream
 replace_script+="data['packages']['toolchain-xtensa-esp32']['version']='$TOOLCHAIN_VERSION';"
 replace_script+="data['packages']['toolchain-xtensa-esp32s2']['version']='$TOOLCHAIN_VERSION';"
+replace_script+="data['packages']['toolchain-xtensa-esp32s3']['version']='$TOOLCHAIN_VERSION';"
 replace_script+="data['packages']['toolchain-riscv32-esp']['version']='$TOOLCHAIN_VERSION';"
-# Add ESP32-S3 Toolchain
-replace_script+="data['packages'].update({'toolchain-xtensa-esp32s3':{'type':'toolchain','optional':True,'owner':'$ESPRESSIF_ORGANIZATION_NAME','version':'$TOOLCHAIN_VERSION'}});"
+# Add new "framework-arduinoespressif32-libs" package
+# Read "package_esp32_index.template.json" to extract a url to a zip package for "esp32-arduino-libs"
+replace_script+="fpackage=open(os.path.join('package', 'package_esp32_index.template.json'), 'r+');"
+replace_script+="package_data=json.load(fpackage);"
+replace_script+="fpackage.close();"
+replace_script+="libs_package_archive_url=next(next(system['url'] for system in tool['systems'] if system['host'] == 'x86_64-pc-linux-gnu') for tool in package_data['packages'][0]['tools'] if tool['name'] == 'esp32-arduino-libs');"
+replace_script+="data['packages'].update({'framework-arduinoespressif32-libs':{'type':'framework','optional':False,'version':libs_package_archive_url}});"
 replace_script+="data['packages']['toolchain-xtensa-esp32'].update({'optional':False});"
 # esptool.py may require an upstream version (for now platformio is the owner)
 replace_script+="data['packages']['tool-esptoolpy']['version']='$ESPTOOLPY_VERSION';"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -63,21 +63,21 @@ jobs:
     - name: Build Sketches
       run: bash ./.github/scripts/on-push.sh
 
-  # # PlatformIO on Windows, Ubuntu and Mac
-  # build-platformio:
-  #   name: PlatformIO on ${{ matrix.os }}
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macOS-latest]
+  # PlatformIO on Windows, Ubuntu and Mac
+  build-platformio:
+    name: PlatformIO on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
 
-  #   steps:
-  #   - uses: actions/checkout@v3
-  #   - uses: actions/setup-python@v4
-  #     with:
-  #       python-version: '3.x'
-  #   - name: Build Sketches
-  #     run: bash ./.github/scripts/on-push.sh 1 1 #equal and non-zero to trigger PIO
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Build Sketches
+      run: bash ./.github/scripts/on-push.sh 1 1 #equal and non-zero to trigger PIO
 
   # build-esp-idf-component:
   #   name: Build with ESP-IDF ${{ matrix.idf_ver }} for ${{ matrix.idf_target }}

--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -37,6 +37,7 @@ partitions_name = board_config.get(
 )
 
 FRAMEWORK_DIR = platform.get_package_dir("framework-arduinoespressif32")
+FRAMEWORK_LIBS_DIR = platform.get_package_dir("framework-arduinoespressif32-libs")
 assert isdir(FRAMEWORK_DIR)
 
 
@@ -84,9 +85,7 @@ def get_bootloader_image(variants_dir):
         if isfile(env.subst(variant_bootloader))
         else generate_bootloader_image(
             join(
-                FRAMEWORK_DIR,
-                "tools",
-                "esp32-arduino-libs",
+                FRAMEWORK_LIBS_DIR,
                 build_mcu,
                 "bin",
                 "bootloader_${__get_board_boot_mode(__env__)}_${__get_board_f_flash(__env__)}.elf",
@@ -160,12 +159,8 @@ def add_tinyuf2_extra_image():
 
 SConscript(
     join(
-        DefaultEnvironment()
-        .PioPlatform()
-        .get_package_dir("framework-arduinoespressif32"),
-        "tools",
-        "esp32-arduino-libs",
-        "%s" % build_mcu,
+        FRAMEWORK_LIBS_DIR,
+        build_mcu,
         "platformio-build.py",
     )
 )


### PR DESCRIPTION
* Update PlatformIO scripts for the upcoming 3.0 core

* Dynamically select proper framework-arduinoespressif32-libs package

With this change the dev-platform will be dynamically configured to pull the latest .zip package with precompiled libraries from extracted from package_esp32_index.template.json

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [ ] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [ ] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [ ] Please **update relevant Documentation** if applicable
4. [ ] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
Please describe your proposed Pull Request and it's impact.

## Tests scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.

(*eg. I have tested my Pull Request on Arduino-esp32 core v2.0.2 with ESP32 and ESP32-S2 Board with this scenario*)

## Related links
Please provide links to related issue, PRs etc.

(*eg. Closes #number of issue*)
