### PR TITLE
HardwareSerial:begin() changes RTS and CTS pins preventing detaching those pins

### DIFF
--- a/cores/esp32/esp32-hal-uart.c
+++ b/cores/esp32/esp32-hal-uart.c
@@ -509,8 +509,6 @@ uart_t* uartBegin(uint8_t uart_nr, uint32_t baudrate, uint32_t config, int8_t rx
         uart->_rxfifo_full_thrhd = rxfifo_full_thrhd;
         uart->_rx_buffer_size = rx_buffer_size;
         uart->_tx_buffer_size = tx_buffer_size;
-        uart->_ctsPin = -1;
-        uart->_rtsPin = -1;
         uart->has_peek = false;
         uart->peek_byte = 0;
     }


### PR DESCRIPTION
Begin() may undo a setpins() that has set RTS and/or CTS pin. This pins are only changed with RTS and CTS.
setpins() can be called after or before begin()
when called before, begin() shall not change those pins.
