### PR TITLE
fix(wifi): Fix WiFi setTxPower and getTxPower

### DIFF
--- a/libraries/WiFi/src/AP.cpp
+++ b/libraries/WiFi/src/AP.cpp
@@ -187,6 +187,10 @@ bool APClass::begin() {
     log_e("AP enable failed!");
     return false;
   }
+  if(!waitStatusBits(ESP_NETIF_STARTED_BIT, 1000)){
+    log_e("Failed to start AP!");
+    return false;
+  }
   return true;
 }
 

--- a/libraries/WiFi/src/STA.cpp
+++ b/libraries/WiFi/src/STA.cpp
@@ -298,6 +298,10 @@ bool STAClass::begin(bool tryConnect) {
     log_e("STA enable failed!");
     return false;
   }
+  if(!waitStatusBits(ESP_NETIF_STARTED_BIT, 1000)){
+    log_e("Failed to start STA!");
+    return false;
+  }
   if (tryConnect) {
     return connect();
   }

--- a/libraries/WiFi/src/WiFiGeneric.cpp
+++ b/libraries/WiFi/src/WiFiGeneric.cpp
@@ -639,7 +639,11 @@ bool WiFiGenericClass::setTxPower(wifi_power_t power) {
     log_w("Neither AP or STA has been started");
     return false;
   }
-  return esp_wifi_set_max_tx_power(power) == ESP_OK;
+  esp_err_t err = esp_wifi_set_max_tx_power(power);
+  if (err != ESP_OK) {
+    log_e("Failed to set TX Power: 0x%x: %s", err, esp_err_to_name(err));
+  }
+  return err == ESP_OK;
 }
 
 wifi_power_t WiFiGenericClass::getTxPower() {
@@ -648,7 +652,9 @@ wifi_power_t WiFiGenericClass::getTxPower() {
     log_w("Neither AP or STA has been started");
     return WIFI_POWER_19_5dBm;
   }
-  if (esp_wifi_get_max_tx_power(&power)) {
+  esp_err_t err = esp_wifi_get_max_tx_power(&power);
+  if (err != ESP_OK) {
+    log_e("Failed to get TX Power: 0x%x: %s", err, esp_err_to_name(err));
     return WIFI_POWER_19_5dBm;
   }
   return (wifi_power_t)power;

--- a/libraries/WiFi/src/WiFiGeneric.h
+++ b/libraries/WiFi/src/WiFiGeneric.h
@@ -44,6 +44,9 @@
 #define wifi_event_id_t network_event_handle_t
 
 typedef enum {
+  WIFI_POWER_21dBm = 84,      // 21dBm
+  WIFI_POWER_20_5dBm = 82,    // 20.5dBm
+  WIFI_POWER_20dBm = 80,      // 20dBm
   WIFI_POWER_19_5dBm = 78,    // 19.5dBm
   WIFI_POWER_19dBm = 76,      // 19dBm
   WIFI_POWER_18_5dBm = 74,    // 18.5dBm


### PR DESCRIPTION
We need to wait for the interface to be started in order to be able to set/get TX Power. Code was returning too early, so calling the functions after `begin()` resulted in failure.

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [ ] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [ ] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [ ] Please **update relevant Documentation** if applicable
4. [ ] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [ ] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
Please describe your proposed Pull Request and it's impact.

## Tests scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.

(*eg. I have tested my Pull Request on Arduino-esp32 core v2.0.2 with ESP32 and ESP32-S2 Board with this scenario*)

## Related links
Please provide links to related issue, PRs etc.

(*eg. Closes #number of issue*)
