### PR TITLE
HTTPClient - add stubs for SSL-related overloads

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -129,7 +129,10 @@ bool HTTPClient::begin(WiFiClient &client, String url) {
 
     _port = (protocol == "https" ? 443 : 80);
     _secure = (protocol == "https");
-    return beginInternal(url, protocol.c_str());
+    if (_secure)
+      return false;
+    else
+      return beginInternal(url, protocol.c_str());
 }
 
 
@@ -160,7 +163,7 @@ bool HTTPClient::begin(WiFiClient &client, String host, uint16_t port, String ur
     _uri = uri;
     _protocol = (https ? "https" : "http");
     _secure = https;
-    return true;
+    return https ? false : true;
 }
 
 

--- a/libraries/HTTPClient/src/HTTPClient.h
+++ b/libraries/HTTPClient/src/HTTPClient.h
@@ -183,10 +183,13 @@ public:
 
 #ifdef HTTPCLIENT_1_1_COMPATIBLE
     bool begin(String url);
-    bool begin(String url, const char* CAcert);
+    [[deprecated("SSL is not supported in this lib")]]
+    bool begin(String url, const char* CAcert){ return false; };
     bool begin(String host, uint16_t port, String uri = "/");
-    bool begin(String host, uint16_t port, String uri, const char* CAcert);
-    bool begin(String host, uint16_t port, String uri, const char* CAcert, const char* cli_cert, const char* cli_key);
+    [[deprecated("SSL is not supported in this lib")]]
+    bool begin(String host, uint16_t port, String uri, const char* CAcert){ return false; };
+    [[deprecated("SSL is not supported in this lib")]]
+    bool begin(String host, uint16_t port, String uri, const char* CAcert, const char* cli_cert, const char* cli_key){ return false; };
 #endif
 
     void end(void);


### PR DESCRIPTION
allows using https URLs in code and handle begin() properly, prevents linker complains
