### PR TITLE
feat(net): Enable IPv6 immediately if already connected

### DIFF
--- a/libraries/Network/src/NetworkInterface.cpp
+++ b/libraries/Network/src/NetworkInterface.cpp
@@ -320,6 +320,15 @@ bool NetworkInterface::hasGlobalIPv6() const {
 bool NetworkInterface::enableIPv6(bool en) {
   if (en) {
     setStatusBits(ESP_NETIF_WANT_IP6_BIT);
+    if (_esp_netif != NULL && connected()) {
+      // If we are already connected, try to enable IPv6 immediately
+      esp_err_t err = esp_netif_create_ip6_linklocal(_esp_netif);
+      if (err != ESP_OK) {
+        log_e("Failed to enable IPv6 Link Local on %s: [%d] %s", desc(), err, esp_err_to_name(err));
+      } else {
+        log_v("Enabled IPv6 Link Local on %s", desc());
+      }
+    }
   } else {
     clearStatusBits(ESP_NETIF_WANT_IP6_BIT);
   }


### PR DESCRIPTION
If the interface is already connected, try to enable IPv6 immediately. Otherwise the interface would need to go through disconnect/connect cycle for IPv6 to be enabled.

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [ ] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [ ] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [ ] Please **update relevant Documentation** if applicable
4. [ ] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [ ] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
Please describe your proposed Pull Request and it's impact.

## Tests scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.

(*eg. I have tested my Pull Request on Arduino-esp32 core v2.0.2 with ESP32 and ESP32-S2 Board with this scenario*)

## Related links
Please provide links to related issue, PRs etc.

(*eg. Closes #number of issue*)
