### PR TITLE
NetworkClientRxBuffer::clear() may not always clear (#10288)

### DIFF
--- a/libraries/Network/src/NetworkClient.cpp
+++ b/libraries/Network/src/NetworkClient.cpp
@@ -148,9 +148,13 @@ public:
 
   void clear() {
     if (r_available()) {
-      fillBuffer();
+      _pos = _fill;
+      while (fillBuffer()) {
+        _pos = _fill;
+      }
     }
-    _pos = _fill;
+    _pos = 0;
+    _fill = 0;
   }
 };
 


### PR DESCRIPTION
Fixes: #10288

*By completing this PR sufficiently, you help us to review this Pull Request quicker and also help improve the quality of Release Notes*

### Checklist
1. [ ] Please provide specific title of the PR describing the change, including the component name (*eg. „Update of Documentation link on Readme.md“*)
2. [ ] Please provide related links (*eg. Issue which will be closed by this Pull Request*)
3. [ ] Please **update relevant Documentation** if applicable
4. [ ] Please check [Contributing guide](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html)
5. [ ] Please **confirm option to "Allow edits and access to secrets by maintainers"** when opening a Pull Request

*This entire section above can be deleted if all items are checked.*

-----------
## Description of Change
Please describe your proposed Pull Request and it's impact.

## Tests scenarios
Please describe on what Hardware and Software combinations you have tested this Pull Request and how.

(*eg. I have tested my Pull Request on Arduino-esp32 core v2.0.2 with ESP32 and ESP32-S2 Board with this scenario*)

## Related links
Please provide links to related issue, PRs etc.

(*eg. Closes #number of issue*)
