### PR TITLE
Tasmota changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 #   idf.py build
 
 set(min_supported_idf_version "5.3.0")
-set(max_supported_idf_version "5.3.99")
+set(max_supported_idf_version "5.4.99")
 set(idf_version "${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}.${IDF_VERSION_PATCH}")
 
 if ("${idf_version}" AND NOT "$ENV{ARDUINO_SKIP_IDF_VERSION_CHECK}")
@@ -25,7 +25,6 @@ endif()
 set(CORE_SRCS
   cores/esp32/base64.cpp
   cores/esp32/cbuf.cpp
-  cores/esp32/chip-debug-report.cpp
   cores/esp32/esp32-hal-adc.c
   cores/esp32/esp32-hal-bt.c
   cores/esp32/esp32-hal-cpu.c
@@ -42,8 +41,7 @@ set(CORE_SRCS
   cores/esp32/esp32-hal-sigmadelta.c
   cores/esp32/esp32-hal-spi.c
   cores/esp32/esp32-hal-time.c
-  cores/esp32/esp32-hal-timer.c
-  cores/esp32/esp32-hal-tinyusb.c
+  cores/esp32/esp32-hal-timer.c 
   cores/esp32/esp32-hal-touch.c
   cores/esp32/esp32-hal-touch-ng.c
   cores/esp32/esp32-hal-uart.c
@@ -66,9 +64,6 @@ set(CORE_SRCS
   cores/esp32/StreamString.cpp
   cores/esp32/Tone.cpp
   cores/esp32/HWCDC.cpp
-  cores/esp32/USB.cpp
-  cores/esp32/USBCDC.cpp
-  cores/esp32/USBMSC.cpp
   cores/esp32/FirmwareMSC.cpp
   cores/esp32/firmware_msc_fat.c
   cores/esp32/wiring_pulse.c
@@ -76,71 +71,50 @@ set(CORE_SRCS
   cores/esp32/WMath.cpp
   cores/esp32/WString.cpp
   )
+if(IDF_TARGET MATCHES "esp32s2|esp32s3|esp32p4" AND CONFIG_TINYUSB_ENABLED)
+  list(APPEND CORE_SRCS
+    cores/esp32/esp32-hal-tinyusb.c
+    cores/esp32/USB.cpp
+    cores/esp32/USBCDC.cpp
+    cores/esp32/USBMSC.cpp)
+endif()
 
 set(ARDUINO_ALL_LIBRARIES
   ArduinoOTA
   AsyncUDP
-  BLE
-  BluetoothSerial
   DNSServer
   EEPROM
-  ESP_I2S
-  ESP_NOW
-  ESP_SR
   ESPmDNS
   Ethernet
   FFat
   FS
   HTTPClient
   HTTPUpdate
-  Insights
   LittleFS
-  Matter
   NetBIOS
   Network
-  OpenThread
   PPP
   Preferences
-  RainMaker
   SD_MMC
   SD
-  SimpleBLE
-  SPIFFS
   SPI
   Ticker
   Update
-  USB
   WebServer
-  NetworkClientSecure
   WiFi
-  WiFiProv
   Wire
-  Zigbee
   )
+if(IDF_TARGET MATCHES "esp32s2|esp32s3|esp32p4" AND CONFIG_TINYUSB_ENABLED)
+  list(APPEND ARDUINO_ALL_LIBRARIES USB)
+endif()
 
 set(ARDUINO_LIBRARY_ArduinoOTA_SRCS libraries/ArduinoOTA/src/ArduinoOTA.cpp)
 
 set(ARDUINO_LIBRARY_AsyncUDP_SRCS libraries/AsyncUDP/src/AsyncUDP.cpp)
 
-set(ARDUINO_LIBRARY_BluetoothSerial_SRCS
-  libraries/BluetoothSerial/src/BluetoothSerial.cpp
-  libraries/BluetoothSerial/src/BTAddress.cpp
-  libraries/BluetoothSerial/src/BTAdvertisedDeviceSet.cpp
-  libraries/BluetoothSerial/src/BTScanResultsSet.cpp)
-
 set(ARDUINO_LIBRARY_DNSServer_SRCS libraries/DNSServer/src/DNSServer.cpp)
 
 set(ARDUINO_LIBRARY_EEPROM_SRCS libraries/EEPROM/src/EEPROM.cpp)
-
-set(ARDUINO_LIBRARY_ESP_I2S_SRCS libraries/ESP_I2S/src/ESP_I2S.cpp)
-
-set(ARDUINO_LIBRARY_ESP_NOW_SRCS
-  libraries/ESP_NOW/src/ESP32_NOW.cpp
-  libraries/ESP_NOW/src/ESP32_NOW_Serial.cpp)
-
-set(ARDUINO_LIBRARY_ESP_SR_SRCS
-  libraries/ESP_SR/src/ESP_SR.cpp
-  libraries/ESP_SR/src/esp32-hal-sr.c)
 
 set(ARDUINO_LIBRARY_ESPmDNS_SRCS libraries/ESPmDNS/src/ESPmDNS.cpp)
 
@@ -156,20 +130,9 @@ set(ARDUINO_LIBRARY_HTTPClient_SRCS libraries/HTTPClient/src/HTTPClient.cpp)
 
 set(ARDUINO_LIBRARY_HTTPUpdate_SRCS libraries/HTTPUpdate/src/HTTPUpdate.cpp)
 
-set(ARDUINO_LIBRARY_Insights_SRCS libraries/Insights/src/Insights.cpp)
-
 set(ARDUINO_LIBRARY_LittleFS_SRCS libraries/LittleFS/src/LittleFS.cpp)
 
 set(ARDUINO_LIBRARY_NetBIOS_SRCS libraries/NetBIOS/src/NetBIOS.cpp)
-
-set(ARDUINO_LIBRARY_OpenThread_SRCS
-  libraries/OpenThread/src/OThreadCLI.cpp
-  libraries/OpenThread/src/OThreadCLI_Util.cpp)
-
-set(ARDUINO_LIBRARY_Matter_SRCS
-  libraries/Matter/src/MatterEndpoints/MatterOnOffLight.cpp
-  libraries/Matter/src/MatterEndpoints/MatterDimmableLight.cpp
-  libraries/Matter/src/Matter.cpp)
 
 set(ARDUINO_LIBRARY_PPP_SRCS
   libraries/PPP/src/PPP.cpp
@@ -177,26 +140,12 @@ set(ARDUINO_LIBRARY_PPP_SRCS
 
 set(ARDUINO_LIBRARY_Preferences_SRCS libraries/Preferences/src/Preferences.cpp)
 
-set(ARDUINO_LIBRARY_RainMaker_SRCS
-  libraries/RainMaker/src/RMaker.cpp
-  libraries/RainMaker/src/RMakerNode.cpp
-  libraries/RainMaker/src/RMakerParam.cpp
-  libraries/RainMaker/src/RMakerDevice.cpp
-  libraries/RainMaker/src/RMakerType.cpp
-  libraries/RainMaker/src/RMakerQR.cpp
-  libraries/RainMaker/src/RMakerUtils.cpp
-  libraries/RainMaker/src/AppInsights.cpp)
-
 set(ARDUINO_LIBRARY_SD_MMC_SRCS libraries/SD_MMC/src/SD_MMC.cpp)
 
 set(ARDUINO_LIBRARY_SD_SRCS
   libraries/SD/src/SD.cpp
   libraries/SD/src/sd_diskio.cpp
   libraries/SD/src/sd_diskio_crc.c)
-
-set(ARDUINO_LIBRARY_SimpleBLE_SRCS libraries/SimpleBLE/src/SimpleBLE.cpp)
-
-set(ARDUINO_LIBRARY_SPIFFS_SRCS libraries/SPIFFS/src/SPIFFS.cpp)
 
 set(ARDUINO_LIBRARY_SPI_SRCS libraries/SPI/src/SPI.cpp)
 
@@ -206,35 +155,33 @@ set(ARDUINO_LIBRARY_Update_SRCS
   libraries/Update/src/Updater.cpp
   libraries/Update/src/HttpsOTAUpdate.cpp)
 
-set(ARDUINO_LIBRARY_USB_SRCS
-  libraries/USB/src/USBHID.cpp
-  libraries/USB/src/USBMIDI.cpp
-  libraries/USB/src/USBHIDMouse.cpp
-  libraries/USB/src/USBHIDKeyboard.cpp
-  libraries/USB/src/keyboardLayout/KeyboardLayout_da_DK.cpp
-  libraries/USB/src/keyboardLayout/KeyboardLayout_de_DE.cpp
-  libraries/USB/src/keyboardLayout/KeyboardLayout_en_US.cpp
-  libraries/USB/src/keyboardLayout/KeyboardLayout_es_ES.cpp
-  libraries/USB/src/keyboardLayout/KeyboardLayout_fr_FR.cpp
-  libraries/USB/src/keyboardLayout/KeyboardLayout_hu_HU.cpp
-  libraries/USB/src/keyboardLayout/KeyboardLayout_it_IT.cpp
-  libraries/USB/src/keyboardLayout/KeyboardLayout_pt_BR.cpp
-  libraries/USB/src/keyboardLayout/KeyboardLayout_pt_PT.cpp
-  libraries/USB/src/keyboardLayout/KeyboardLayout_sv_SE.cpp
-  libraries/USB/src/USBHIDGamepad.cpp
-  libraries/USB/src/USBHIDConsumerControl.cpp
-  libraries/USB/src/USBHIDSystemControl.cpp
-  libraries/USB/src/USBHIDVendor.cpp
-  libraries/USB/src/USBVendor.cpp)
+if(IDF_TARGET MATCHES "esp32s2|esp32s3|esp32p4" AND CONFIG_TINYUSB_ENABLED)
+  set(ARDUINO_LIBRARY_USB_SRCS
+    libraries/USB/src/USBHID.cpp
+    libraries/USB/src/USBMIDI.cpp
+    libraries/USB/src/USBHIDMouse.cpp
+    libraries/USB/src/USBHIDKeyboard.cpp
+    libraries/USB/src/keyboardLayout/KeyboardLayout_da_DK.cpp
+    libraries/USB/src/keyboardLayout/KeyboardLayout_de_DE.cpp
+    libraries/USB/src/keyboardLayout/KeyboardLayout_en_US.cpp
+    libraries/USB/src/keyboardLayout/KeyboardLayout_es_ES.cpp
+    libraries/USB/src/keyboardLayout/KeyboardLayout_fr_FR.cpp
+    libraries/USB/src/keyboardLayout/KeyboardLayout_hu_HU.cpp
+    libraries/USB/src/keyboardLayout/KeyboardLayout_it_IT.cpp
+    libraries/USB/src/keyboardLayout/KeyboardLayout_pt_BR.cpp
+    libraries/USB/src/keyboardLayout/KeyboardLayout_pt_PT.cpp
+    libraries/USB/src/keyboardLayout/KeyboardLayout_sv_SE.cpp
+    libraries/USB/src/USBHIDGamepad.cpp
+    libraries/USB/src/USBHIDConsumerControl.cpp
+    libraries/USB/src/USBHIDSystemControl.cpp
+    libraries/USB/src/USBHIDVendor.cpp
+    libraries/USB/src/USBVendor.cpp)
+endif()
 
 set(ARDUINO_LIBRARY_WebServer_SRCS
   libraries/WebServer/src/WebServer.cpp
   libraries/WebServer/src/Parsing.cpp
   libraries/WebServer/src/detail/mimetable.cpp)
-
-set(ARDUINO_LIBRARY_NetworkClientSecure_SRCS
-  libraries/NetworkClientSecure/src/ssl_client.cpp
-  libraries/NetworkClientSecure/src/NetworkClientSecure.cpp)
 
 set(ARDUINO_LIBRARY_Network_SRCS
   libraries/Network/src/NetworkInterface.cpp
@@ -254,54 +201,7 @@ set(ARDUINO_LIBRARY_WiFi_SRCS
   libraries/WiFi/src/STA.cpp
   libraries/WiFi/src/AP.cpp)
 
-set(ARDUINO_LIBRARY_WiFiProv_SRCS libraries/WiFiProv/src/WiFiProv.cpp)
-
 set(ARDUINO_LIBRARY_Wire_SRCS libraries/Wire/src/Wire.cpp)
-
-set(ARDUINO_LIBRARY_Zigbee_SRCS
-  libraries/Zigbee/src/ZigbeeCore.cpp
-  libraries/Zigbee/src/ZigbeeEP.cpp
-  libraries/Zigbee/src/ZigbeeHandlers.cpp
-  libraries/Zigbee/src/ep/ZigbeeColorDimmableLight.cpp
-  libraries/Zigbee/src/ep/ZigbeeColorDimmerSwitch.cpp
-  libraries/Zigbee/src/ep/ZigbeeLight.cpp
-  libraries/Zigbee/src/ep/ZigbeeSwitch.cpp
-  libraries/Zigbee/src/ep/ZigbeeTempSensor.cpp
-  libraries/Zigbee/src/ep/ZigbeeThermostat.cpp
-  )
-
-set(ARDUINO_LIBRARY_BLE_SRCS
-  libraries/BLE/src/BLE2901.cpp
-  libraries/BLE/src/BLE2902.cpp
-  libraries/BLE/src/BLE2904.cpp
-  libraries/BLE/src/BLEAddress.cpp
-  libraries/BLE/src/BLEAdvertisedDevice.cpp
-  libraries/BLE/src/BLEAdvertising.cpp
-  libraries/BLE/src/BLEBeacon.cpp
-  libraries/BLE/src/BLECharacteristic.cpp
-  libraries/BLE/src/BLECharacteristicMap.cpp
-  libraries/BLE/src/BLEClient.cpp
-  libraries/BLE/src/BLEDescriptor.cpp
-  libraries/BLE/src/BLEDescriptorMap.cpp
-  libraries/BLE/src/BLEDevice.cpp
-  libraries/BLE/src/BLEEddystoneTLM.cpp
-  libraries/BLE/src/BLEEddystoneURL.cpp
-  libraries/BLE/src/BLEExceptions.cpp
-  libraries/BLE/src/BLEHIDDevice.cpp
-  libraries/BLE/src/BLERemoteCharacteristic.cpp
-  libraries/BLE/src/BLERemoteDescriptor.cpp
-  libraries/BLE/src/BLERemoteService.cpp
-  libraries/BLE/src/BLEScan.cpp
-  libraries/BLE/src/BLESecurity.cpp
-  libraries/BLE/src/BLEServer.cpp
-  libraries/BLE/src/BLEService.cpp
-  libraries/BLE/src/BLEServiceMap.cpp
-  libraries/BLE/src/BLEUtils.cpp
-  libraries/BLE/src/BLEUUID.cpp
-  libraries/BLE/src/BLEValue.cpp
-  libraries/BLE/src/FreeRTOS.cpp
-  libraries/BLE/src/GeneralUtils.cpp
-  )
 
 set(ARDUINO_LIBRARIES_SRCS)
 set(ARDUINO_LIBRARIES_REQUIRES)
@@ -324,15 +224,7 @@ set(includedirs variants/${CONFIG_ARDUINO_VARIANT}/ cores/esp32/ ${ARDUINO_LIBRA
 set(srcs ${CORE_SRCS} ${ARDUINO_LIBRARIES_SRCS})
 set(priv_includes cores/esp32/libb64)
 set(requires spi_flash esp_partition mbedtls wpa_supplicant esp_adc esp_eth http_parser esp_ringbuf esp_driver_gptimer esp_driver_usb_serial_jtag driver)
-set(priv_requires fatfs nvs_flash app_update spiffs bootloader_support bt esp_hid usb esp_psram ${ARDUINO_LIBRARIES_REQUIRES})
-
-if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_OpenThread)
-  #if(CONFIG_SOC_IEEE802154_SUPPORTED) # Does not work!
-  #if(CONFIG_OPENTHREAD_ENABLED) # Does not work!
-  if(IDF_TARGET STREQUAL "esp32c6" OR IDF_TARGET STREQUAL "esp32h2") # Sadly only this works
-    list(APPEND requires openthread)
-  endif()
-endif()
+set(priv_requires fatfs nvs_flash app_update bootloader_support bt esp_hid usb esp_psram ${ARDUINO_LIBRARIES_REQUIRES})
 
 if(IDF_TARGET STREQUAL "esp32p4")
   list(APPEND requires esp_driver_touch_sens)
@@ -383,15 +275,6 @@ endif()
 if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_ArduinoOTA)
     maybe_add_component(esp_https_ota)
 endif()
-if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_ESP_SR)
-    maybe_add_component(espressif__esp_sr)
-endif()
-if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_Matter)
-    maybe_add_component(espressif__esp_matter)
-endif()
 if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_LittleFS)
     maybe_add_component(joltwallet__littlefs)
-endif()
-if(NOT CONFIG_ARDUINO_SELECTIVE_COMPILATION OR CONFIG_ARDUINO_SELECTIVE_WiFiProv)
-    maybe_add_component(espressif__network_provisioning)
 endif()

--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -266,11 +266,6 @@ config ARDUINO_SELECTIVE_Wire
     depends on ARDUINO_SELECTIVE_COMPILATION
     default y
 
-config ARDUINO_SELECTIVE_ESP_SR
-    bool "Enable ESP-SR"
-    depends on ARDUINO_SELECTIVE_COMPILATION
-    default y
-
 config ARDUINO_SELECTIVE_EEPROM
     bool "Enable EEPROM"
     depends on ARDUINO_SELECTIVE_COMPILATION
@@ -291,11 +286,6 @@ config ARDUINO_SELECTIVE_Update
     depends on ARDUINO_SELECTIVE_COMPILATION
     default y
 
-config ARDUINO_SELECTIVE_Zigbee
-    bool "Enable Zigbee"
-    depends on ARDUINO_SELECTIVE_COMPILATION
-    default y
-
 config ARDUINO_SELECTIVE_FS
     bool "Enable FS"
     depends on ARDUINO_SELECTIVE_COMPILATION
@@ -308,11 +298,6 @@ config ARDUINO_SELECTIVE_SD
 
 config ARDUINO_SELECTIVE_SD_MMC
     bool "Enable SD_MMC"
-    depends on ARDUINO_SELECTIVE_COMPILATION && ARDUINO_SELECTIVE_FS
-    default y
-
-config ARDUINO_SELECTIVE_SPIFFS
-    bool "Enable SPIFFS"
     depends on ARDUINO_SELECTIVE_COMPILATION && ARDUINO_SELECTIVE_FS
     default y
 
@@ -365,12 +350,6 @@ config ARDUINO_SELECTIVE_ESPmDNS
 config ARDUINO_SELECTIVE_HTTPClient
     bool "Enable HTTPClient"
     depends on ARDUINO_SELECTIVE_COMPILATION && ARDUINO_SELECTIVE_Network
-    select ARDUINO_SELECTIVE_NetworkClientSecure
-    default y
-
-config ARDUINO_SELECTIVE_Matter
-    bool "Enable Matter"
-    depends on ARDUINO_SELECTIVE_COMPILATION && ARDUINO_SELECTIVE_Network
     default y
 
 config ARDUINO_SELECTIVE_NetBIOS
@@ -387,46 +366,6 @@ config ARDUINO_SELECTIVE_WebServer
 config ARDUINO_SELECTIVE_WiFi
     bool "Enable WiFi"
     depends on ARDUINO_SELECTIVE_COMPILATION && ARDUINO_SELECTIVE_Network
-    default y
-
-config ARDUINO_SELECTIVE_NetworkClientSecure
-    bool "Enable NetworkClientSecure"
-    depends on ARDUINO_SELECTIVE_COMPILATION && ARDUINO_SELECTIVE_Network
-    default y
-
-config ARDUINO_SELECTIVE_WiFiProv
-    bool "Enable WiFiProv"
-    depends on ARDUINO_SELECTIVE_COMPILATION && ARDUINO_SELECTIVE_Network && ARDUINO_SELECTIVE_WiFi
-    default y
-
-config ARDUINO_SELECTIVE_BLE
-    bool "Enable BLE"
-    depends on ARDUINO_SELECTIVE_COMPILATION
-    default y
-
-config ARDUINO_SELECTIVE_BluetoothSerial
-    bool "Enable BluetoothSerial"
-    depends on ARDUINO_SELECTIVE_COMPILATION
-    default y
-
-config ARDUINO_SELECTIVE_SimpleBLE
-    bool "Enable SimpleBLE"
-    depends on ARDUINO_SELECTIVE_COMPILATION
-    default y
-
-config ARDUINO_SELECTIVE_RainMaker
-    bool "Enable RainMaker"
-    depends on ARDUINO_SELECTIVE_COMPILATION
-    default y
-
-config ARDUINO_SELECTIVE_OpenThread
-    bool "Enable OpenThread"
-    depends on ARDUINO_SELECTIVE_COMPILATION
-    default y
-
-config ARDUINO_SELECTIVE_Insights
-    bool "Enable Insights"
-    depends on ARDUINO_SELECTIVE_COMPILATION
     default y
 
 endmenu

--- a/README.md
+++ b/README.md
@@ -1,30 +1,6 @@
-# Arduino core for the ESP32, ESP32-P4, ESP32-S2, ESP32-S3, ESP32-C3, ESP32-C6 and ESP32-H2
+# Tasmota Platformio Arduino for ESP32, ESP32-P4, ESP32-S2, ESP32-S3, ESP32-C2, ESP32-C3, ESP32-C6 and ESP32-H2
 
-[![Build Status](https://github.com/espressif/arduino-esp32/actions/workflows/push.yml/badge.svg?branch=master&event=push)](https://github.com/espressif/arduino-esp32/actions/workflows/push.yml) [![External Libraries Test](https://github.com/espressif/arduino-esp32/actions/workflows/lib.yml/badge.svg?branch=master&event=schedule)](https://github.com/espressif/arduino-esp32/blob/gh-pages/LIBRARIES_TEST.md) [![Hardware Tests](https://github.com/espressif/arduino-esp32/blob/gh-pages/runtime-tests-results/badge.svg)](https://github.com/espressif/arduino-esp32/actions/workflows/tests_results.yml)
-
-### Need help or have a question? Join the chat at [Gitter](https://gitter.im/espressif/arduino-esp32) or [open a new Discussion](https://github.com/espressif/arduino-esp32/discussions)
-
-## Contents
-
-  - [Development Status](#development-status)
-  - [Development Planning](#development-planning)
-  - [Documentation](#documentation)
-  - [Supported Chips](#supported-chips)
-  - [Decoding exceptions](#decoding-exceptions)
-  - [Issue/Bug report template](#issuebug-report-template)
-  - [Contributing](#contributing)
-
-### Development Status
-
-Latest Stable Release  [![Release Version](https://img.shields.io/github/release/espressif/arduino-esp32.svg?style=plastic)](https://github.com/espressif/arduino-esp32/releases/latest/) [![Release Date](https://img.shields.io/github/release-date/espressif/arduino-esp32.svg?style=plastic)](https://github.com/espressif/arduino-esp32/releases/latest/) [![Downloads](https://img.shields.io/github/downloads/espressif/arduino-esp32/latest/total.svg?style=plastic)](https://github.com/espressif/arduino-esp32/releases/latest/)
-
-Latest Development Release  [![Release Version](https://img.shields.io/github/release/espressif/arduino-esp32/all.svg?style=plastic)](https://github.com/espressif/arduino-esp32/releases/) [![Release Date](https://img.shields.io/github/release-date-pre/espressif/arduino-esp32.svg?style=plastic)](https://github.com/espressif/arduino-esp32/releases/) [![Downloads](https://img.shields.io/github/downloads-pre/espressif/arduino-esp32/latest/total.svg?style=plastic)](https://github.com/espressif/arduino-esp32/releases/)
-
-### Development Planning
-
-Our Development is fully tracked on this public **[Roadmap 🎉](https://github.com/orgs/espressif/projects/3)**
-
-For even more information you can join our **[Monthly Community Meetings 🔔](https://github.com/espressif/arduino-esp32/discussions/categories/monthly-community-meetings).**
+### [![GitHub Releases](https://img.shields.io/github/downloads/tasmota/arduino-esp32/total?label=downloads)](https://github.com/tasmota/arduino-esp32/releases/latest)
 
 ### Documentation
 
@@ -36,56 +12,21 @@ You can use the [Arduino-ESP32 Online Documentation](https://docs.espressif.com/
 
 ---
 
-**APIs compatibility with ESP8266 and Arduino-CORE (Arduino.cc) is explained [here](https://docs.espressif.com/projects/arduino-esp32/en/latest/libraries.html#apis).**
-
----
-
-* [Getting Started](https://docs.espressif.com/projects/arduino-esp32/en/latest/getting_started.html)
-* [Installing (Windows, Linux and macOS)](https://docs.espressif.com/projects/arduino-esp32/en/latest/installing.html)
-* [Libraries](https://docs.espressif.com/projects/arduino-esp32/en/latest/libraries.html)
-* [Arduino as an ESP-IDF component](https://docs.espressif.com/projects/arduino-esp32/en/latest/esp-idf_component.html)
-* [FAQ](https://docs.espressif.com/projects/arduino-esp32/en/latest/faq.html)
-* [Troubleshooting](https://docs.espressif.com/projects/arduino-esp32/en/latest/troubleshooting.html)
-
 ### Supported Chips
 
-Here are the ESP32 series supported by the Arduino-ESP32 project:
+Here are the ESP32 series supported by the Tasmota Arduino-ESP32 project:
 
 | **SoC**  | **Stable** | **Development** |                                           **Datasheet**                                           |
 |----------|:----------:|:---------------:|:-------------------------------------------------------------------------------------------------:|
-| ESP32    |     Yes    |       Yes       |    [ESP32](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf)    |
+| ESP32    |     Yes    |       Yes       | [ESP32](https://www.espressif.com/sites/default/files/documentation/esp32_datasheet_en.pdf)    |
+| ESP32solo1|    Yes    |       Yes       | [ESP32solo1](https://www.espressif.com/sites/default/files/documentation/esp32-solo-1_datasheet_en.pdf)  |
 | ESP32-S2 |     Yes    |       Yes       | [ESP32-S2](https://www.espressif.com/sites/default/files/documentation/esp32-s2_datasheet_en.pdf) |
-| ESP32-C3 |     Yes    |       Yes       | [ESP32-C3](https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf) |
 | ESP32-S3 |     Yes    |       Yes       | [ESP32-S3](https://www.espressif.com/sites/default/files/documentation/esp32-s3_datasheet_en.pdf) |
+| ESP32-C2 |     Yes    |       Yes       | [ESP32-C2](https://www.espressif.com/sites/default/files/documentation/esp8684_datasheet_en.pdf)  |
+| ESP32-C3 |     Yes    |       Yes       | [ESP32-C3](https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf) |
 | ESP32-C6 |     Yes    |       Yes       | [ESP32-C6](https://www.espressif.com/sites/default/files/documentation/esp32-c6_datasheet_en.pdf) |
 | ESP32-H2 |     Yes    |       Yes       | [ESP32-H2](https://www.espressif.com/sites/default/files/documentation/esp32-h2_datasheet_en.pdf) |
 | ESP32-P4 |     No     |       Yes       | [ESP32-P4](https://www.espressif.com/sites/default/files/documentation/esp32-p4_datasheet_en.pdf) |
 
-> [!NOTE]
-> ESP32-C2 is also supported by Arduino-ESP32 but requires rebuilding the static libraries. This is not trivial and requires a good understanding of the ESP-IDF
-> build system. For more information, see the [Lib Builder documentation](https://docs.espressif.com/projects/arduino-esp32/en/latest/lib_builder.html).
 
 For more details visit the [supported chips](https://docs.espressif.com/projects/arduino-esp32/en/latest/getting_started.html#supported-soc-s) documentation page.
-
-### Decoding exceptions
-
-You can use [EspExceptionDecoder](https://github.com/me-no-dev/EspExceptionDecoder) to get meaningful call trace.
-
-### Issue/Bug report template
-
-Before reporting an issue, make sure you've searched for similar one that was already created. Also make sure to go through all the issues labeled as [Type: For reference](https://github.com/espressif/arduino-esp32/issues?q=is%3Aissue+label%3A%22Type%3A+For+reference%22+).
-
-Finally, if you are sure no one else had the issue, follow the **Issue template** or **Feature request template** while reporting any [new Issue](https://github.com/espressif/arduino-esp32/issues/new/choose).
-
-### External libraries compilation test
-
-We have set-up CI testing for external libraries for ESP32 Arduino core. You can check test results in the file [LIBRARIES_TEST](https://github.com/espressif/arduino-esp32/blob/gh-pages/LIBRARIES_TEST.md).
-For more information and how to add your library to the test see [external library testing](https://docs.espressif.com/projects/arduino-esp32/en/latest/external_libraries_test.html) in the documentation.
-
-### Contributing
-
-We welcome contributions to the Arduino ESP32 project!
-
-See [contributing](https://docs.espressif.com/projects/arduino-esp32/en/latest/contributing.html) in the documentation for more information on how to contribute to the project.
-
-> We would like to have this repository in a polite and friendly atmosphere, so please be kind and respectful to others. For more details, look at [Code of Conduct](https://github.com/espressif/arduino-esp32/blob/master/CODE_OF_CONDUCT.md).

--- a/cores/esp32/FirmwareMSC.h
+++ b/cores/esp32/FirmwareMSC.h
@@ -14,7 +14,9 @@
 
 #pragma once
 #include <stdbool.h>
+#if defined __has_include && __has_include("USBMSC.h")
 #include "USBMSC.h"
+#endif
 
 #if CONFIG_TINYUSB_MSC_ENABLED
 

--- a/cores/esp32/HWCDC.cpp
+++ b/cores/esp32/HWCDC.cpp
@@ -11,7 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+#if defined __has_include && __has_include("USB.h")
 #include "USB.h"
+#endif
 #if SOC_USB_SERIAL_JTAG_SUPPORTED
 
 #include "esp32-hal.h"

--- a/cores/esp32/HardwareSerial.h
+++ b/cores/esp32/HardwareSerial.h
@@ -51,7 +51,9 @@
 #include "esp32-hal.h"
 #include "soc/soc_caps.h"
 #include "HWCDC.h"
+#if defined __has_include && __has_include("USBCDC.h")
 #include "USBCDC.h"
+#endif
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"

--- a/cores/esp32/esp32-hal-cpu.c
+++ b/cores/esp32/esp32-hal-cpu.c
@@ -268,7 +268,7 @@ bool setCpuFrequencyMhz(uint32_t cpu_freq_mhz) {
 #ifdef CONFIG_IDF_TARGET_ESP32P4
                                           : "17.5M"),
 #else
-                                                                                                                           : "8M")),
+                                          : "8M")),
 #endif
     conf.source_freq_mhz, conf.div, conf.freq_mhz, apb
   );

--- a/cores/esp32/main.cpp
+++ b/cores/esp32/main.cpp
@@ -10,7 +10,9 @@
 #endif
 #endif
 
+#if defined __has_include && __has_include("chip-debug-report.h")
 #include "chip-debug-report.h"
+#endif
 
 #ifndef ARDUINO_LOOP_STACK_SIZE
 #ifndef CONFIG_ARDUINO_LOOP_STACK_SIZE
@@ -49,6 +51,7 @@ void loopTask(void *pvParameters) {
   // sets UART0 (default console) RX/TX pins as already configured in boot or as defined in variants/pins_arduino.h
   Serial0.setPins(gpioNumberToDigitalPin(SOC_RX0), gpioNumberToDigitalPin(SOC_TX0));
 #endif
+#if defined __has_include && __has_include("chip-debug-report.h")
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_DEBUG
   printBeforeSetupInfo();
 #else
@@ -56,13 +59,16 @@ void loopTask(void *pvParameters) {
     printBeforeSetupInfo();
   }
 #endif
+#endif
   setup();
+#if defined __has_include && __has_include("chip-debug-report.h")
 #if ARDUHAL_LOG_LEVEL >= ARDUHAL_LOG_LEVEL_DEBUG
   printAfterSetupInfo();
 #else
   if (shouldPrintChipDebugReport()) {
     printAfterSetupInfo();
   }
+#endif
 #endif
   for (;;) {
 #if CONFIG_FREERTOS_UNICORE

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -44,62 +44,17 @@ files:
     - "platform.txt"
     - "programmers.txt"
 dependencies:
-  idf: ">=5.3,<5.4"
+  idf: ">=5.3,<=5.4"
   # mdns 1.2.1 is necessary to build H2 with no WiFi
   espressif/mdns:
     version: "^1.2.3"
     require: public
   espressif/esp_modem:
     version: "^1.1.0"
-  espressif/esp-zboss-lib:
-    version: "^1.0.1"
     rules:
-      - if: "target not in [esp32c2, esp32p4]"
-  espressif/esp-zigbee-lib:
-    version: "^1.0.1"
-    rules:
-      - if: "target not in [esp32c2, esp32p4]"
+      - if: "target in [esp32, esp32s2, esp32s3, esp32h2, esp32p4]"
   espressif/esp-dsp:
-    version: "^1.3.4"
-    rules:
-      - if: "target != esp32c2"
-  # RainMaker Start (Fixed versions, because Matter supports only Insights 1.0.1)
-  espressif/network_provisioning:
-    version: "1.0.2"
-  espressif/esp_rainmaker:
-    version: "1.5.0"
-    rules:
-      - if: "target not in [esp32c2, esp32p4]"
-  espressif/rmaker_common:
-    version: "1.4.6"
-    rules:
-      - if: "target not in [esp32c2, esp32p4]"
-  espressif/esp_insights:
-    version: "1.0.1"
-    rules:
-      - if: "target not in [esp32c2, esp32p4]"
-  # New version breaks esp_insights 1.0.1
-  espressif/esp_diag_data_store:
-    version: "1.0.1"
-    rules:
-      - if: "target not in [esp32c2, esp32p4]"
-  espressif/esp_diagnostics:
-    version: "1.0.2"
-    rules:
-      - if: "target not in [esp32c2, esp32p4]"
-  espressif/cbor:
-    version: "0.6.0~1"
-    rules:
-      - if: "target not in [esp32c2, esp32p4]"
-  espressif/qrcode:
-    version: "0.1.0~2"
-    rules:
-      - if: "target not in [esp32c2, esp32p4]"
-  # RainMaker End
-  espressif/esp-sr:
-    version: "^1.4.2"
-    rules:
-      - if: "target in [esp32s3]"
+    version: "^1.4.12"
   espressif/esp_hosted:
     version: "^0.0.22"
     rules:
@@ -108,18 +63,11 @@ dependencies:
     version: "^0.4.1"
     rules:
       - if: "target == esp32p4"
-  espressif/libsodium:
-    version: "^1.0.20~1"
-    require: public
-  espressif/esp-modbus:
-    version: "^1.0.15"
-    require: public
   joltwallet/littlefs:
-    version: "^1.10.2"
-  chmorgan/esp-libhelix-mp3:
-    version: "1.0.3"
+    version: "^1.14.1"
+  espressif/esp32-camera:
+    version: "master"
+    git: https://github.com/espressif/esp32-camera.git
     require: public
-examples:
-  - path: ./idf_component_examples/hello_world
-  - path: ./idf_component_examples/hw_cdc_hello_world
-  - path: ./idf_component_examples/esp_matter_light
+    rules:
+      - if: "target in [esp32, esp32s2, esp32s3, esp32p4]"

--- a/libraries/Ethernet/src/ETH.cpp
+++ b/libraries/Ethernet/src/ETH.cpp
@@ -19,6 +19,10 @@
  */
 
 // Disable the automatic pin remapping of the API calls in this file
+
+#include "sdkconfig.h"
+#if CONFIG_ETH_ENABLED
+
 #define ARDUINO_CORE_BUILD
 
 #include "ETH.h"
@@ -286,6 +290,7 @@ bool ETHClass::begin(eth_phy_type_t type, int32_t phy_addr, int mdc, int mdio, i
     case ETH_PHY_TLK110:  phy = esp_eth_phy_new_ip101(&phy_config); break;
     case ETH_PHY_RTL8201: phy = esp_eth_phy_new_rtl8201(&phy_config); break;
     case ETH_PHY_DP83848: phy = esp_eth_phy_new_dp83848(&phy_config); break;
+    case ETH_PHY_JL1101:  phy = esp_eth_phy_new_jl1101(&phy_config); break;
     case ETH_PHY_KSZ8041: phy = esp_eth_phy_new_ksz80xx(&phy_config); break;
     case ETH_PHY_KSZ8081: phy = esp_eth_phy_new_ksz80xx(&phy_config); break;
     default:              log_e("Unsupported PHY %d", type); break;
@@ -1056,3 +1061,5 @@ size_t ETHClass::printDriverInfo(Print &out) const {
 }
 
 ETHClass ETH;
+
+#endif /* CONFIG_ETH_ENABLED */

--- a/libraries/Ethernet/src/ETH.h
+++ b/libraries/Ethernet/src/ETH.h
@@ -18,6 +18,9 @@
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include "sdkconfig.h"
+#if CONFIG_ETH_ENABLED
+
 #ifndef _ETH_H_
 #define _ETH_H_
 
@@ -127,6 +130,7 @@ typedef enum {
   ETH_PHY_LAN8720,
   ETH_PHY_TLK110,
   ETH_PHY_RTL8201,
+  ETH_PHY_JL1101,
   ETH_PHY_DP83848,
   ETH_PHY_KSZ8041,
   ETH_PHY_KSZ8081,
@@ -249,3 +253,4 @@ private:
 extern ETHClass ETH;
 
 #endif /* _ETH_H_ */
+#endif /* CONFIG_ETH_ENABLED */

--- a/libraries/HTTPClient/src/HTTPClient.cpp
+++ b/libraries/HTTPClient/src/HTTPClient.cpp
@@ -35,6 +35,8 @@
 /// Cookie jar support
 #include <time.h>
 
+#define HTTPCLIENT_NOSECURE
+
 #ifdef HTTPCLIENT_1_1_COMPATIBLE
 class TransportTraits {
 public:

--- a/libraries/HTTPClient/src/HTTPClient.h
+++ b/libraries/HTTPClient/src/HTTPClient.h
@@ -31,6 +31,10 @@
 #define HTTPCLIENT_1_1_COMPATIBLE
 #endif
 
+#ifndef HTTPCLIENT_NOSECURE
+#define HTTPCLIENT_NOSECURE
+#endif
+
 #include <memory>
 #include <Arduino.h>
 #include <NetworkClient.h>

--- a/libraries/Network/src/NetworkEvents.h
+++ b/libraries/Network/src/NetworkEvents.h
@@ -5,18 +5,20 @@
  */
 #pragma once
 
+#include "sdkconfig.h"
 #include "soc/soc_caps.h"
 #include "esp_err.h"
 #include "esp_event.h"
 #include "esp_netif_types.h"
+#if CONFIG_ETH_ENABLED
 #include "esp_eth_driver.h"
+#endif
 #include <functional>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/queue.h"
 #include "freertos/semphr.h"
 #include "freertos/event_groups.h"
-#include "sdkconfig.h"
 #if defined NETWORK_EVENTS_MUTEX && SOC_CPU_CORES_NUM > 1
 #include <mutex>
 #endif  // defined NETWORK_EVENTS_MUTEX &&  SOC_CPU_CORES_NUM > 1
@@ -98,7 +100,9 @@ typedef union {
   ip_event_ap_staipassigned_t wifi_ap_staipassigned;
   ip_event_got_ip_t got_ip;
   ip_event_got_ip6_t got_ip6;
+#if CONFIG_ETH_ENABLED 
   esp_eth_handle_t eth_connected;
+#endif
 #if SOC_WIFI_SUPPORTED || CONFIG_ESP_WIFI_REMOTE_ENABLED
   wifi_event_sta_scan_done_t wifi_scan_done;
   wifi_event_sta_authmode_change_t wifi_sta_authmode_change;

--- a/libraries/Update/src/Update.h
+++ b/libraries/Update/src/Update.h
@@ -25,7 +25,6 @@
 #define UPDATE_ERROR_NO_PARTITION (10)
 #define UPDATE_ERROR_BAD_ARGUMENT (11)
 #define UPDATE_ERROR_ABORT        (12)
-#define UPDATE_ERROR_DECRYPT      (13)
 
 #define UPDATE_SIZE_UNKNOWN 0xFFFFFFFF
 
@@ -33,15 +32,7 @@
 #define U_SPIFFS 100
 #define U_AUTH   200
 
-#define ENCRYPTED_BLOCK_SIZE       16
-#define ENCRYPTED_TWEAK_BLOCK_SIZE 32
-#define ENCRYPTED_KEY_SIZE         32
-
-#define U_AES_DECRYPT_NONE         0
-#define U_AES_DECRYPT_AUTO         1
-#define U_AES_DECRYPT_ON           2
-#define U_AES_DECRYPT_MODE_MASK    3
-#define U_AES_IMAGE_DECRYPTING_BIT 4
+#define ENCRYPTED_BLOCK_SIZE 16
 
 #define SPI_SECTORS_PER_BLOCK 16  // usually large erase block is 32k/64k
 #define SPI_FLASH_BLOCK_SIZE  (SPI_SECTORS_PER_BLOCK * SPI_FLASH_SEC_SIZE)
@@ -62,15 +53,6 @@ public:
       Will return false if there is not enough space
     */
   bool begin(size_t size = UPDATE_SIZE_UNKNOWN, int command = U_FLASH, int ledPin = -1, uint8_t ledOn = LOW, const char *label = NULL);
-
-  /*
-     Setup decryption configuration
-     Crypt Key is 32bytes(256bits) block of data, use the same key as used to encrypt image file
-     Crypt Address, use the same value as used to encrypt image file
-     Crypt Config,  use the same value as used to encrypt image file
-     Crypt Mode,    used to select if image files should be decrypted or not
-    */
-  bool setupCrypt(const uint8_t *cryptKey = 0, size_t cryptAddress = 0, uint8_t cryptConfig = 0xf, int cryptMode = U_AES_DECRYPT_AUTO);
 
   /*
       Writes a buffer to the flash and increments the address
@@ -100,30 +82,6 @@ public:
   bool end(bool evenIfRemaining = false);
 
   /*
-      sets AES256 key(32 bytes) used for decrypting image file
-    */
-  bool setCryptKey(const uint8_t *cryptKey);
-
-  /*
-      sets crypt mode used on image files
-    */
-  bool setCryptMode(const int cryptMode);
-
-  /*
-      sets address used for decrypting image file
-    */
-  void setCryptAddress(const size_t cryptAddress) {
-    _cryptAddress = cryptAddress & 0x00fffff0;
-  }
-
-  /*
-      sets crypt config used for decrypting image file
-    */
-  void setCryptConfig(const uint8_t cryptConfig) {
-    _cryptCfg = cryptConfig & 0x0f;
-  }
-
-  /*
       Aborts the running update
     */
   void abort();
@@ -137,9 +95,8 @@ public:
 
   /*
       sets the expected MD5 for the firmware (hexString)
-      If calc_post_decryption is true, the update library will calculate the MD5 after the decryption, if false the calculation occurs before the decryption
     */
-  bool setMD5(const char *expected_md5, bool calc_post_decryption = true);
+  bool setMD5(const char *expected_md5);
 
   /*
       returns the MD5 String of the successfully ended firmware
@@ -236,8 +193,6 @@ public:
 private:
   void _reset();
   void _abort(uint8_t err);
-  void _cryptKeyTweak(size_t cryptAddress, uint8_t *tweaked_key);
-  bool _decryptBuffer();
   bool _writeBuffer();
   bool _verifyHeader(uint8_t data);
   bool _verifyEnd();
@@ -245,8 +200,6 @@ private:
   bool _chkDataInBlock(const uint8_t *data, size_t len) const;  // check if block contains any data or is empty
 
   uint8_t _error;
-  uint8_t *_cryptKey;
-  uint8_t *_cryptBuffer;
   uint8_t *_buffer;
   uint8_t *_skipBuffer;
   size_t _bufferLen;
@@ -258,15 +211,10 @@ private:
   const esp_partition_t *_partition;
 
   String _target_md5;
-  bool _target_md5_decrypted = true;
   MD5Builder _md5;
 
   int _ledPin;
   uint8_t _ledOn;
-
-  uint8_t _cryptMode;
-  size_t _cryptAddress;
-  uint8_t _cryptCfg;
 };
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_UPDATE)

--- a/libraries/Update/src/Updater.cpp
+++ b/libraries/Update/src/Updater.cpp
@@ -9,7 +9,6 @@
 #include "spi_flash_mmap.h"
 #include "esp_ota_ops.h"
 #include "esp_image_format.h"
-#include "mbedtls/aes.h"
 
 static const char *_err2str(uint8_t _error) {
   if (_error == UPDATE_ERROR_OK) {
@@ -38,8 +37,6 @@ static const char *_err2str(uint8_t _error) {
     return ("Bad Argument");
   } else if (_error == UPDATE_ERROR_ABORT) {
     return ("Aborted");
-  } else if (_error == UPDATE_ERROR_DECRYPT) {
-    return ("Decryption error");
   }
   return ("UNKNOWN");
 }
@@ -67,8 +64,7 @@ bool UpdateClass::_enablePartition(const esp_partition_t *partition) {
 }
 
 UpdateClass::UpdateClass()
-  : _error(0), _cryptKey(0), _cryptBuffer(0), _buffer(0), _skipBuffer(0), _bufferLen(0), _size(0), _progress_callback(NULL), _progress(0), _paroffset(0),
-    _command(U_FLASH), _partition(NULL), _cryptMode(U_AES_DECRYPT_AUTO), _cryptAddress(0), _cryptCfg(0xf) {}
+  : _error(0), _buffer(0), _bufferLen(0), _size(0), _progress_callback(NULL), _progress(0), _paroffset(0), _command(U_FLASH), _partition(NULL) {}
 
 UpdateClass &UpdateClass::onProgress(THandlerFunction_Progress fn) {
   _progress_callback = fn;
@@ -83,7 +79,6 @@ void UpdateClass::_reset() {
     delete[] _skipBuffer;
   }
 
-  _cryptBuffer = nullptr;
   _buffer = nullptr;
   _skipBuffer = nullptr;
   _bufferLen = 0;
@@ -175,48 +170,6 @@ bool UpdateClass::begin(size_t size, int command, int ledPin, uint8_t ledOn, con
   return true;
 }
 
-bool UpdateClass::setupCrypt(const uint8_t *cryptKey, size_t cryptAddress, uint8_t cryptConfig, int cryptMode) {
-  if (setCryptKey(cryptKey)) {
-    if (setCryptMode(cryptMode)) {
-      setCryptAddress(cryptAddress);
-      setCryptConfig(cryptConfig);
-      return true;
-    }
-  }
-  return false;
-}
-
-bool UpdateClass::setCryptKey(const uint8_t *cryptKey) {
-  if (!cryptKey) {
-    if (_cryptKey) {
-      delete[] _cryptKey;
-      _cryptKey = 0;
-      log_d("AES key unset");
-    }
-    return false;  //key cleared, no key to decrypt with
-  }
-  //initialize
-  if (!_cryptKey) {
-    _cryptKey = new (std::nothrow) uint8_t[ENCRYPTED_KEY_SIZE];
-  }
-  if (!_cryptKey) {
-    log_e("new failed");
-    return false;
-  }
-  memcpy(_cryptKey, cryptKey, ENCRYPTED_KEY_SIZE);
-  return true;
-}
-
-bool UpdateClass::setCryptMode(const int cryptMode) {
-  if (cryptMode >= U_AES_DECRYPT_NONE && cryptMode <= U_AES_DECRYPT_ON) {
-    _cryptMode = cryptMode;
-  } else {
-    log_e("bad crypt mode argument %i", cryptMode);
-    return false;
-  }
-  return true;
-}
-
 void UpdateClass::_abort(uint8_t err) {
   _reset();
   _error = err;
@@ -226,140 +179,7 @@ void UpdateClass::abort() {
   _abort(UPDATE_ERROR_ABORT);
 }
 
-void UpdateClass::_cryptKeyTweak(size_t cryptAddress, uint8_t *tweaked_key) {
-  memcpy(tweaked_key, _cryptKey, ENCRYPTED_KEY_SIZE);
-  if (_cryptCfg == 0) {
-    return;  //no tweaking needed, use crypt key as-is
-  }
-
-  const uint8_t pattern[] = {23, 23, 23, 14, 23, 23, 23, 12, 23, 23, 23, 10, 23, 23, 23, 8};
-  int pattern_idx = 0;
-  int key_idx = 0;
-  int bit_len = 0;
-  uint32_t tweak = 0;
-  cryptAddress &= 0x00ffffe0;  //bit 23-5
-  cryptAddress <<= 8;          //bit23 shifted to bit31(MSB)
-  while (pattern_idx < sizeof(pattern)) {
-    tweak = cryptAddress << (23 - pattern[pattern_idx]);  //bit shift for small patterns
-    // alternative to: tweak = rotl32(tweak,8 - bit_len);
-    tweak = (tweak << (8 - bit_len)) | (tweak >> (24 + bit_len));  //rotate to line up with end of previous tweak bits
-    bit_len += pattern[pattern_idx++] - 4;                         //add number of bits in next pattern(23-4 = 19bits = 23bit to 5bit)
-    while (bit_len > 7) {
-      tweaked_key[key_idx++] ^= tweak;  //XOR byte
-      // alternative to: tweak = rotl32(tweak, 8);
-      tweak = (tweak << 8) | (tweak >> 24);  //compiler should optimize to use rotate(fast)
-      bit_len -= 8;
-    }
-    tweaked_key[key_idx] ^= tweak;  //XOR remaining bits, will XOR zeros if no remaining bits
-  }
-  if (_cryptCfg == 0xf) {
-    return;  //return with fully tweaked key
-  }
-
-  //some of tweaked key bits need to be restore back to crypt key bits
-  const uint8_t cfg_bits[] = {67, 65, 63, 61};
-  key_idx = 0;
-  pattern_idx = 0;
-  while (key_idx < ENCRYPTED_KEY_SIZE) {
-    bit_len += cfg_bits[pattern_idx];
-    if ((_cryptCfg & (1 << pattern_idx)) == 0) {  //restore crypt key bits
-      while (bit_len > 0) {
-        if (bit_len > 7 || ((_cryptCfg & (2 << pattern_idx)) == 0)) {  //restore a crypt key byte
-          tweaked_key[key_idx] = _cryptKey[key_idx];
-        } else {  //MSBits restore crypt key bits, LSBits keep as tweaked bits
-          tweaked_key[key_idx] &= (0xff >> bit_len);
-          tweaked_key[key_idx] |= (_cryptKey[key_idx] & (~(0xff >> bit_len)));
-        }
-        key_idx++;
-        bit_len -= 8;
-      }
-    } else {  //keep tweaked key bits
-      while (bit_len > 0) {
-        if (bit_len < 8 && ((_cryptCfg & (2 << pattern_idx)) == 0)) {  //MSBits keep as tweaked bits, LSBits restore crypt key bits
-          tweaked_key[key_idx] &= (~(0xff >> bit_len));
-          tweaked_key[key_idx] |= (_cryptKey[key_idx] & (0xff >> bit_len));
-        }
-        key_idx++;
-        bit_len -= 8;
-      }
-    }
-    pattern_idx++;
-  }
-}
-
-bool UpdateClass::_decryptBuffer() {
-  if (!_cryptKey) {
-    log_w("AES key not set");
-    return false;
-  }
-  if (_bufferLen % ENCRYPTED_BLOCK_SIZE != 0) {
-    log_e("buffer size error");
-    return false;
-  }
-  if (!_cryptBuffer) {
-    _cryptBuffer = new (std::nothrow) uint8_t[ENCRYPTED_BLOCK_SIZE];
-  }
-  if (!_cryptBuffer) {
-    log_e("new failed");
-    return false;
-  }
-  uint8_t tweaked_key[ENCRYPTED_KEY_SIZE];  //tweaked crypt key
-  int done = 0;
-
-  /*
-        Mbedtls functions will be replaced with esp_aes functions when hardware acceleration is available
-
-        To Do:
-        Replace mbedtls for the cases where there's no hardware acceleration
-     */
-
-  mbedtls_aes_context ctx;  //initialize AES
-  mbedtls_aes_init(&ctx);
-  while ((_bufferLen - done) >= ENCRYPTED_BLOCK_SIZE) {
-    for (int i = 0; i < ENCRYPTED_BLOCK_SIZE; i++) {
-      _cryptBuffer[(ENCRYPTED_BLOCK_SIZE - 1) - i] = _buffer[i + done];  //reverse order 16 bytes to decrypt
-    }
-    if (((_cryptAddress + _progress + done) % ENCRYPTED_TWEAK_BLOCK_SIZE) == 0 || done == 0) {
-      _cryptKeyTweak(_cryptAddress + _progress + done, tweaked_key);  //update tweaked crypt key
-      if (mbedtls_aes_setkey_enc(&ctx, tweaked_key, 256)) {
-        return false;
-      }
-      if (mbedtls_aes_setkey_dec(&ctx, tweaked_key, 256)) {
-        return false;
-      }
-    }
-    if (mbedtls_aes_crypt_ecb(&ctx, MBEDTLS_AES_ENCRYPT, _cryptBuffer, _cryptBuffer)) {  //use MBEDTLS_AES_ENCRYPT to decrypt flash code
-      return false;
-    }
-    for (int i = 0; i < ENCRYPTED_BLOCK_SIZE; i++) {
-      _buffer[i + done] = _cryptBuffer[(ENCRYPTED_BLOCK_SIZE - 1) - i];  //reverse order 16 bytes from decrypt
-    }
-    done += ENCRYPTED_BLOCK_SIZE;
-  }
-  return true;
-}
-
 bool UpdateClass::_writeBuffer() {
-  //first bytes of loading image, check to see if loading image needs decrypting
-  if (!_progress) {
-    _cryptMode &= U_AES_DECRYPT_MODE_MASK;
-    if ((_cryptMode == U_AES_DECRYPT_ON) || ((_command == U_FLASH) && (_cryptMode & U_AES_DECRYPT_AUTO) && (_buffer[0] != ESP_IMAGE_HEADER_MAGIC))) {
-      _cryptMode |= U_AES_IMAGE_DECRYPTING_BIT;  //set to decrypt the loading image
-      log_d("Decrypting OTA Image");
-    }
-  }
-
-  if (!_target_md5_decrypted) {
-    _md5.add(_buffer, _bufferLen);
-  }
-
-  //check if data in buffer needs decrypting
-  if (_cryptMode & U_AES_IMAGE_DECRYPTING_BIT) {
-    if (!_decryptBuffer()) {
-      _abort(UPDATE_ERROR_DECRYPT);
-      return false;
-    }
-  }
   //first bytes of new firmware
   uint8_t skip = 0;
   if (!_progress && _command == U_FLASH) {
@@ -409,9 +229,7 @@ bool UpdateClass::_writeBuffer() {
   if (!_progress && _command == U_FLASH) {
     _buffer[0] = ESP_IMAGE_HEADER_MAGIC;
   }
-  if (_target_md5_decrypted) {
-    _md5.add(_buffer, _bufferLen);
-  }
+  _md5.add(_buffer, _bufferLen);
   _progress += _bufferLen;
   _bufferLen = 0;
   if (_progress_callback) {
@@ -453,13 +271,12 @@ bool UpdateClass::_verifyEnd() {
   return false;
 }
 
-bool UpdateClass::setMD5(const char *expected_md5, bool calc_post_decryption) {
+bool UpdateClass::setMD5(const char *expected_md5) {
   if (strlen(expected_md5) != 32) {
     return false;
   }
   _target_md5 = expected_md5;
   _target_md5.toLowerCase();
-  _target_md5_decrypted = calc_post_decryption;
   return true;
 }
 
@@ -532,11 +349,9 @@ size_t UpdateClass::writeStream(Stream &data) {
     return 0;
   }
 
-  if (_command == U_FLASH && !_cryptMode) {
-    if (!_verifyHeader(data.peek())) {
-      _reset();
-      return 0;
-    }
+  if (!_verifyHeader(data.peek())) {
+    _reset();
+    return 0;
   }
 
   if (_ledPin != -1) {

--- a/libraries/WebServer/src/WebServer.cpp
+++ b/libraries/WebServer/src/WebServer.cpp
@@ -460,7 +460,7 @@ void WebServer::handleClient() {
       case HC_WAIT_CLOSE:
         if (_currentClient.isSSE()) {
           // Never close connection
-          _statusChange = millis();
+          //_statusChange = millis();
         }
         // Wait for client to close the connection
         if (millis() - _statusChange <= HTTP_MAX_CLOSE_WAIT) {

--- a/libraries/WiFi/src/STA.cpp
+++ b/libraries/WiFi/src/STA.cpp
@@ -421,6 +421,7 @@ bool STAClass::connect(const char *ssid, const char *passphrase, int32_t channel
   return true;
 }
 
+#if CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT
 /**
  * Start Wifi connection with a WPA2 Enterprise AP
  * if passphrase is set the most secure supported mode will be automatically selected
@@ -519,6 +520,7 @@ bool STAClass::connect(
 
   return connect(wpa2_ssid, NULL, channel, bssid, tryConnect);  //connect to wifi
 }
+#endif /* CONFIG_ESP_WIFI_ENTERPRISE_SUPPORT */
 
 bool STAClass::disconnect(bool eraseap, unsigned long timeout) {
   if (eraseap) {

--- a/libraries/WiFi/src/WiFiGeneric.h
+++ b/libraries/WiFi/src/WiFiGeneric.h
@@ -33,7 +33,9 @@
 #include "IPAddress.h"
 #include "esp_smartconfig.h"
 #include "esp_netif_types.h"
+#if CONFIG_ETH_ENABLED
 #include "esp_eth_driver.h"
+#endif
 #if CONFIG_NETWORK_PROV_NETWORK_TYPE_WIFI
 #include "network_provisioning/manager.h"
 #endif

--- a/libraries/WiFi/src/WiFiSTA.cpp
+++ b/libraries/WiFi/src/WiFiSTA.cpp
@@ -65,13 +65,13 @@ wl_status_t WiFiSTAClass::status() {
 
 wl_status_t WiFiSTAClass::begin(
   const char *wpa2_ssid, wpa2_auth_method_t method, const char *wpa2_identity, const char *wpa2_username, const char *wpa2_password, const char *ca_pem,
-  const char *client_crt, const char *client_key, int ttls_phase2_type, int32_t channel, const uint8_t *bssid, bool connect
+  const char *client_crt, const char *client_key, int32_t channel, const uint8_t *bssid, bool connect
 ) {
   if (!STA.begin()) {
     return WL_CONNECT_FAILED;
   }
 
-  if (!STA.connect(wpa2_ssid, method, wpa2_identity, wpa2_username, wpa2_password, ca_pem, client_crt, client_key, ttls_phase2_type, channel, bssid, connect)) {
+  if (!STA.connect(wpa2_ssid, method, wpa2_identity, wpa2_username, wpa2_password, ca_pem, client_crt, client_key, channel, bssid, connect)) {
     return WL_CONNECT_FAILED;
   }
 

--- a/libraries/WiFi/src/WiFiSTA.h
+++ b/libraries/WiFi/src/WiFiSTA.h
@@ -56,8 +56,7 @@ public:
   bool connect(const char *ssid, const char *passphrase = NULL, int32_t channel = 0, const uint8_t *bssid = NULL, bool connect = true);
   bool connect(
     const char *wpa2_ssid, wpa2_auth_method_t method, const char *wpa2_identity = NULL, const char *wpa2_username = NULL, const char *wpa2_password = NULL,
-    const char *ca_pem = NULL, const char *client_crt = NULL, const char *client_key = NULL, int ttls_phase2_type = -1, int32_t channel = 0,
-    const uint8_t *bssid = 0, bool connect = true
+    const char *ca_pem = NULL, const char *client_crt = NULL, const char *client_key = NULL, int32_t channel = 0, const uint8_t *bssid = 0, bool connect = true
   );
   bool disconnect(bool eraseap = false, unsigned long timeout = 0);
   bool reconnect();
@@ -111,17 +110,16 @@ public:
 
   wl_status_t begin(
     const char *wpa2_ssid, wpa2_auth_method_t method, const char *wpa2_identity = NULL, const char *wpa2_username = NULL, const char *wpa2_password = NULL,
-    const char *ca_pem = NULL, const char *client_crt = NULL, const char *client_key = NULL, int ttls_phase2_type = -1, int32_t channel = 0,
-    const uint8_t *bssid = 0, bool connect = true
+    const char *ca_pem = NULL, const char *client_crt = NULL, const char *client_key = NULL, int32_t channel = 0, const uint8_t *bssid = 0, bool connect = true
   );
   wl_status_t begin(
     const String &wpa2_ssid, wpa2_auth_method_t method, const String &wpa2_identity = (const char *)NULL, const String &wpa2_username = (const char *)NULL,
     const String &wpa2_password = (const char *)NULL, const String &ca_pem = (const char *)NULL, const String &client_crt = (const char *)NULL,
-    const String &client_key = (const char *)NULL, int ttls_phase2_type = -1, int32_t channel = 0, const uint8_t *bssid = 0, bool connect = true
+    const String &client_key = (const char *)NULL, int32_t channel = 0, const uint8_t *bssid = 0, bool connect = true
   ) {
     return begin(
       wpa2_ssid.c_str(), method, wpa2_identity.c_str(), wpa2_username.c_str(), wpa2_password.c_str(), ca_pem.c_str(), client_crt.c_str(), client_key.c_str(),
-      ttls_phase2_type, channel, bssid, connect
+      channel, bssid, connect
     );
   }
   wl_status_t begin(const char *ssid, const char *passphrase = NULL, int32_t channel = 0, const uint8_t *bssid = NULL, bool connect = true);

--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -35,7 +35,7 @@ build_mcu = board_config.get("build.mcu", "").lower()
 partitions_name = board_config.get("build.partitions", board_config.get("build.arduino.partitions", ""))
 
 FRAMEWORK_DIR = platform.get_package_dir("framework-arduinoespressif32")
-FRAMEWORK_LIBS_DIR = platform.get_package_dir("framework-arduinoespressif32-libs")
+FRAMEWORK_LIBS_DIR = join(FRAMEWORK_DIR, "tools", "esp32-arduino-libs")
 assert isdir(FRAMEWORK_DIR)
 
 
@@ -184,9 +184,15 @@ corelib_env.Append(CPPDEFINES=["ARDUINO_CORE_BUILD"])
 libs = []
 
 variants_dir = join(FRAMEWORK_DIR, "variants")
+try:
+    build_variants_dir = join(board_config.get("build.variants_dir"))
+except Exception:
+    build_variants_dir = ""
 
 if "build.variants_dir" in board_config:
-    variants_dir = join("$PROJECT_DIR", board_config.get("build.variants_dir"))
+    if len(build_variants_dir) > 1:
+        variants_dir = join("$PROJECT_DIR", board_config.get("build.variants_dir"))
+
 
 if "build.variant" in board_config:
     env.Append(CPPPATH=[join(variants_dir, board_config.get("build.variant"))])
@@ -209,6 +215,15 @@ env.Prepend(LIBS=libs)
 # Process framework extra images
 #
 
+# Tasmota places extra images "safeboot" in custom variants folder in project directory
+build_name = join(board_config.get("name"))
+if len(build_variants_dir) > 1:
+    EXTRA_IMG_DIR = join(variants_dir)
+else:
+    EXTRA_IMG_DIR = FRAMEWORK_DIR
+    if "tasmota" in build_name.lower():
+        EXTRA_IMG_DIR = join(EXTRA_IMG_DIR, "variants", "tasmota")
+
 env.Append(
     LIBSOURCE_DIRS=[join(FRAMEWORK_DIR, "libraries")],
     FLASH_EXTRA_IMAGES=[
@@ -219,7 +234,7 @@ env.Append(
         ("0x8000", join(env.subst("$BUILD_DIR"), "partitions.bin")),
         ("0xe000", join(FRAMEWORK_DIR, "tools", "partitions", "boot_app0.bin")),
     ]
-    + [(offset, join(FRAMEWORK_DIR, img)) for offset, img in board_config.get("upload.arduino.flash_extra_images", [])],
+    + [(offset, join(EXTRA_IMG_DIR, img)) for offset, img in board_config.get("upload.arduino.flash_extra_images", [])],
 )
 
 # Add an extra UF2 image if the 'TinyUF2' partition is selected

--- a/variants/esp32p4/pins_arduino.h
+++ b/variants/esp32p4/pins_arduino.h
@@ -10,8 +10,8 @@
 static const uint8_t TX = 37;
 static const uint8_t RX = 38;
 
-static const uint8_t SDA = 7;
-static const uint8_t SCL = 8;
+static const uint8_t SDA = 13;
+static const uint8_t SCL = 12;
 
 // Use GPIOs 36 or lower on the P4 DevKit to avoid LDO power issues with high numbered GPIOs.
 static const uint8_t SS = 26;


### PR DESCRIPTION
* optional Ethernet support (JL1101 driver added)
* esp-modem only esp32, esp32s2 and esp32s3
* remove `OpenThread`
* remove all BT BLE libraries
* remove zigbee
* remove SPIFFS
* remove Client Secure
* remove Provisioning
* remove TfLite, Insights and Rainmaker
* make GPIOViewer working see https://github.com/arendst/Tasmota/commit/969611835c803197e0a683c9cf9647d074bdfae8
